### PR TITLE
@Deprecated in getter setter

### DIFF
--- a/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
+++ b/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
@@ -253,6 +253,7 @@ class EntityProcessor implements TransformationParticipant<MutableClassDeclarati
 						«IF f.docComment.defined»«f.docComment»«ELSE»Get the value of the «cls.simpleName» entity property «f.simpleName».«ENDIF»
 						@return the found «f.simpleName» or null if not set.
 					'''
+					deprecated = f.deprecated
 					primarySourceElement = f
 					returnType = typeConversions
 						.get(f.type.simpleName)?.newTypeReference
@@ -278,6 +279,7 @@ class EntityProcessor implements TransformationParticipant<MutableClassDeclarati
 						Set the value of the «cls.simpleName» entity property «f.simpleName».<p>
 						This will trigger a change event for the observers.
 					'''
+					deprecated = f.deprecated
 					primarySourceElement = f
 					val setterType = typeConversions
 						.get(f.type.simpleName)?.newTypeReference

--- a/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
+++ b/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
@@ -276,8 +276,8 @@ class EntityProcessor implements TransformationParticipant<MutableClassDeclarati
 				
 				cls.addMethod('set' + f.simpleName.toFirstUpper) [
 					docComment = '''
-						Set the value of the «cls.simpleName» entity property «f.simpleName».<p>
-						This will trigger a change event for the observers.
+						«IF f.docComment.defined»«f.docComment»«ELSE»Set the value of the «cls.simpleName» entity property «f.simpleName».«ENDIF»
+						<p>This will trigger a change event for the observers.
 					'''
 					deprecated = f.deprecated
 					primarySourceElement = f

--- a/src/main/xtend-gen/nl/kii/entity/processors/EntityProcessor.java
+++ b/src/main/xtend-gen/nl/kii/entity/processors/EntityProcessor.java
@@ -604,6 +604,8 @@ public class EntityProcessor implements TransformationParticipant<MutableClassDe
                 _builder.append(" or null if not set.");
                 _builder.newLineIfNotEmpty();
                 it.setDocComment(_builder.toString());
+                boolean _isDeprecated = f.isDeprecated();
+                it.setDeprecated(_isDeprecated);
                 context.setPrimarySourceElement(it, f);
                 TypeReference _type = f.getType();
                 String _simpleName_3 = _type.getSimpleName();
@@ -688,6 +690,8 @@ public class EntityProcessor implements TransformationParticipant<MutableClassDe
                 _builder.append("This will trigger a change event for the observers.");
                 _builder.newLine();
                 it.setDocComment(_builder.toString());
+                boolean _isDeprecated = f.isDeprecated();
+                it.setDeprecated(_isDeprecated);
                 context.setPrimarySourceElement(it, f);
                 TypeReference _type = f.getType();
                 String _simpleName_2 = _type.getSimpleName();

--- a/src/main/xtend-gen/nl/kii/entity/processors/EntityProcessor.java
+++ b/src/main/xtend-gen/nl/kii/entity/processors/EntityProcessor.java
@@ -679,15 +679,24 @@ public class EntityProcessor implements TransformationParticipant<MutableClassDe
             final Procedure1<MutableMethodDeclaration> _function_14 = new Procedure1<MutableMethodDeclaration>() {
               public void apply(final MutableMethodDeclaration it) {
                 StringConcatenation _builder = new StringConcatenation();
-                _builder.append("Set the value of the ");
-                String _simpleName = cls.getSimpleName();
-                _builder.append(_simpleName, "");
-                _builder.append(" entity property ");
-                String _simpleName_1 = f.getSimpleName();
-                _builder.append(_simpleName_1, "");
-                _builder.append(".<p>");
+                {
+                  String _docComment = f.getDocComment();
+                  boolean _defined = OptExtensions.<Object>defined(_docComment);
+                  if (_defined) {
+                    String _docComment_1 = f.getDocComment();
+                    _builder.append(_docComment_1, "");
+                  } else {
+                    _builder.append("Set the value of the ");
+                    String _simpleName = cls.getSimpleName();
+                    _builder.append(_simpleName, "");
+                    _builder.append(" entity property ");
+                    String _simpleName_1 = f.getSimpleName();
+                    _builder.append(_simpleName_1, "");
+                    _builder.append(".");
+                  }
+                }
                 _builder.newLineIfNotEmpty();
-                _builder.append("This will trigger a change event for the observers.");
+                _builder.append("<p>This will trigger a change event for the observers.");
                 _builder.newLine();
                 it.setDocComment(_builder.toString());
                 boolean _isDeprecated = f.isDeprecated();


### PR DESCRIPTION
1) @Deprecated will now get propagated to the generated getters and setters.

2) Field’s docComment will now also show in the generated setter (previously only getter).